### PR TITLE
feat: 데이터셋/모델 자동화 유틸리티 추가 및 로더 안전성 강화

### DIFF
--- a/runtime-env/scripts/download_yolov5m.py
+++ b/runtime-env/scripts/download_yolov5m.py
@@ -1,0 +1,50 @@
+import os
+import subprocess
+import shutil
+
+def main():
+    # 1. ultralytics 패키지 설치 확인 및 설치
+    try:
+        import ultralytics
+    except ImportError:
+        print("[*] 'ultralytics' 패키지가 없습니다. 설치를 진행합니다...")
+        subprocess.check_call(["pip", "install", "ultralytics"])
+        
+    from ultralytics import YOLO
+    
+    # 루트 디렉토리 및 모델이 저장될 목표 디렉토리 절대경로 산출
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    models_dir = os.path.join(project_root, "models", "yolov5m")
+    os.makedirs(models_dir, exist_ok=True)
+    
+    print(f"[*] 다운로드 및 ONNX Export를 시작합니다 (저장 폴더: {models_dir})...")
+    
+    # PyTorch 모델 가중치가 scripts 폴더 같은 엉뚱한 곳에 받아지지 않도록 작업 폴더 변경
+    original_cwd = os.getcwd()
+    os.chdir(models_dir)
+    
+    try:
+        # 2. 모델 로드 (자동으로 yolov5m.pt 가 models_dir 내부에 다운로드 됨)
+        # v8 패키지에서 v5 모델을 사용할 경우 확장자로 자동 식별합니다.
+        model = YOLO("yolov5m.pt") 
+        
+        # 3. ONNX 포맷으로 추출 (export)
+        print("[*] 모델을 ONNX 규격으로 내보내는 중...")
+        exported_path = model.export(format="onnx", opset=12, imgsz=[640,640], simplify=True)
+        print(f"[+] Export 결과물: {exported_path}")
+        
+        # Export 된 파일을 안전하게 찾아서 변경된 target_path 와 매치시킵니다.
+        target_path = os.path.join(models_dir, "yolov5m.onnx")
+        
+        if os.path.abspath(exported_path) != os.path.abspath(target_path):
+            shutil.move(exported_path, target_path)
+            
+        print(f"[+] YOLOv5m ONNX 모델이 준비되었습니다: {target_path}")
+        
+    except Exception as e:
+        print(f"[!] ONNX Export 중 에러가 발생했습니다: {e}")
+    finally:
+        os.chdir(original_cwd)
+
+if __name__ == "__main__":
+    main()

--- a/runtime-env/scripts/download_yolov5m.py
+++ b/runtime-env/scripts/download_yolov5m.py
@@ -1,50 +1,69 @@
 import os
 import subprocess
 import shutil
+import tempfile
+import urllib.request
+import sys
 
 def main():
-    # 1. ultralytics 패키지 설치 확인 및 설치
-    try:
-        import ultralytics
-    except ImportError:
-        print("[*] 'ultralytics' 패키지가 없습니다. 설치를 진행합니다...")
-        subprocess.check_call(["pip", "install", "ultralytics"])
-        
-    from ultralytics import YOLO
-    
-    # 루트 디렉토리 및 모델이 저장될 목표 디렉토리 절대경로 산출
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
     models_dir = os.path.join(project_root, "models", "yolov5m")
     os.makedirs(models_dir, exist_ok=True)
+    target_onnx = os.path.join(models_dir, "yolov5m.onnx")
+
+    print("[*] 오리지널 YOLOv5m (Legacy) 모델 다운로드 및 Export를 시작합니다...")
     
-    print(f"[*] 다운로드 및 ONNX Export를 시작합니다 (저장 폴더: {models_dir})...")
-    
-    # PyTorch 모델 가중치가 scripts 폴더 같은 엉뚱한 곳에 받아지지 않도록 작업 폴더 변경
-    original_cwd = os.getcwd()
-    os.chdir(models_dir)
-    
-    try:
-        # 2. 모델 로드 (자동으로 yolov5m.pt 가 models_dir 내부에 다운로드 됨)
-        # v8 패키지에서 v5 모델을 사용할 경우 확장자로 자동 식별합니다.
-        model = YOLO("yolov5m.pt") 
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # 1. YOLOv5 공식(레거시) 레포지토리 클론 (폴더가 비어있어야 함)
+        print("[*] YOLOv5 레포지토리를 임시 폴더에 Clone 합니다...")
+        subprocess.check_call(["git", "clone", "https://github.com/ultralytics/yolov5", temp_dir])
+
+        # 2. 모델 가중치 분리(강제) 다운로드 (내부 다운로더 멈춤 방지 및 진행률 표시)
+        pt_url = "https://github.com/ultralytics/yolov5/releases/download/v7.0/yolov5m.pt"
+        pt_path = os.path.join(temp_dir, "yolov5m.pt")
+        print(f"[*] 모델 가중치 사전 다운로드 중: {pt_url}")
         
-        # 3. ONNX 포맷으로 추출 (export)
-        print("[*] 모델을 ONNX 규격으로 내보내는 중...")
-        exported_path = model.export(format="onnx", opset=12, imgsz=[640,640], simplify=True)
-        print(f"[+] Export 결과물: {exported_path}")
+        try:
+            req = urllib.request.Request(pt_url, headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'})
+            with urllib.request.urlopen(req) as response, open(pt_path, 'wb') as out_file:
+                total_length = response.getheader('content-length')
+                if total_length is None:
+                    shutil.copyfileobj(response, out_file)
+                else:
+                    total_length = int(total_length)
+                    fetched = 0
+                    while True:
+                        chunk = response.read(8192)
+                        if not chunk:
+                            break
+                        out_file.write(chunk)
+                        fetched += len(chunk)
+                        percent = int(fetched * 100 / total_length)
+                        print(f"\rDownloading... {percent}% ({fetched/(1024*1024):.1f}MB / {total_length/(1024*1024):.1f}MB)", end="")
+                        sys.stdout.flush()
+            print("\n[+] 가중치 다운로드 완료!")
+        except Exception as e:
+            print(f"\n[!] 가중치 다운로드 실패: {e}")
+            return
         
-        # Export 된 파일을 안전하게 찾아서 변경된 target_path 와 매치시킵니다.
-        target_path = os.path.join(models_dir, "yolov5m.onnx")
+        # 3. export.py 실행 (미리 다운 받은 yolov5m.pt로 ONNX 변환)
+        print("[*] export.py를 통해 Legacy YOLOv5m 포맷(25200, 85)으로 파싱합니다...")
+        export_script = os.path.join(temp_dir, "export.py")
+        subprocess.check_call([
+            "python", export_script, 
+            "--weights", "yolov5m.pt", 
+            "--include", "onnx", 
+            "--opset", "17",
+            "--dynamic"
+        ], cwd=temp_dir)
         
-        if os.path.abspath(exported_path) != os.path.abspath(target_path):
-            shutil.move(exported_path, target_path)
-            
-        print(f"[+] YOLOv5m ONNX 모델이 준비되었습니다: {target_path}")
-        
-    except Exception as e:
-        print(f"[!] ONNX Export 중 에러가 발생했습니다: {e}")
-    finally:
-        os.chdir(original_cwd)
+        # 4. 결과물 복사
+        exported_onnx = os.path.join(temp_dir, "yolov5m.onnx")
+        if os.path.exists(exported_onnx):
+            shutil.copy(exported_onnx, target_onnx)
+            print(f"[+] 오리지널 YOLOv5m ONNX 모델이 준비되었습니다: {target_onnx}")
+        else:
+            print("[!] Export 실패: 변환된 onnx 파일을 찾을 수 없습니다.")
 
 if __name__ == "__main__":
     main()

--- a/runtime-env/scripts/load_coco128.py
+++ b/runtime-env/scripts/load_coco128.py
@@ -1,0 +1,32 @@
+import os
+import urllib.request
+import zipfile
+
+def main():
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    datasets_dir = os.path.join(project_root, "datasets")
+    os.makedirs(datasets_dir, exist_ok=True)
+    
+    url = "https://github.com/ultralytics/yolov5/releases/download/v1.0/coco128.zip"
+    zip_path = os.path.join(datasets_dir, "coco128.zip")
+    
+    print(f"[*] Downloading COCO128 from {url} to {datasets_dir}...")
+    try:
+        urllib.request.urlretrieve(url, zip_path)
+    except Exception as e:
+        print(f"[!] 다운로드 실패: {e}")
+        return
+    
+    print("[*] Extracting zip file...")
+    try:
+        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+            # ultralytics coco128.zip 에는 자기 자신의 루트 폴더('coco128')가 내장되어 있습니다.
+            zip_ref.extractall(datasets_dir)
+    except Exception as e:
+        print(f"[!] 압축 해제 실패: {e}")
+        return
+        
+    print(f"[+] COCO128 dataset is ready at {os.path.join(datasets_dir, 'coco128')}")
+
+if __name__ == "__main__":
+    main()

--- a/runtime-env/scripts/load_coco128.py
+++ b/runtime-env/scripts/load_coco128.py
@@ -11,8 +11,16 @@ def main():
     zip_path = os.path.join(datasets_dir, "coco128.zip")
     
     print(f"[*] Downloading COCO128 from {url} to {datasets_dir}...")
+    
+    def reporthook(block_num, block_size, total_size):
+        fetched = block_num * block_size
+        if total_size > 0:
+            percent = min(100, fetched * 100 // total_size)
+            print(f"\rDownloading... {percent}% ({fetched/(1024*1024):.1f}MB / {total_size/(1024*1024):.1f}MB)", end="")
+
     try:
-        urllib.request.urlretrieve(url, zip_path)
+        urllib.request.urlretrieve(url, zip_path, reporthook)
+        print("\n[+] Download complete!")
     except Exception as e:
         print(f"[!] 다운로드 실패: {e}")
         return

--- a/runtime-env/scripts/prepare_squad_numpy.py
+++ b/runtime-env/scripts/prepare_squad_numpy.py
@@ -1,0 +1,151 @@
+"""
+BERT SQuAD 질의응답(QA) 평가를 위한 순수 Numpy 데이터셋 오프라인 굽기 스크립트.
+
+HuggingFace Hub에서 SQuAD validation 세트를 다운로드 한 후,
+`tokenizer`의 `return_offsets_mapping=True` 옵션을 활용하여
+단어(Character) 단위의 정답지 위치(answer_start)를 
+BERT 기반의 질문응답 타겟 모델(예: `csarron/bert-base-uncased-squad-v1`)이
+이해할 수 있는 토큰(Token) 인덱스 위치(start_positions, end_positions)로 
+수리적으로 변환(Mapping)한 뒤 디스크에 영구 저장(.npy)합니다. 
+"""
+
+import os
+import argparse
+import numpy as np
+
+try:
+    from transformers import AutoTokenizer
+    from datasets import load_dataset
+except ImportError:
+    print("[Error] 현재 환경에 HuggingFace 라이브러리가 없습니다.")
+    print("        실행 전 다음 명령어로 설치해주세요: pip install transformers datasets")
+    import sys; sys.exit(1)
+
+def main():
+    parser = argparse.ArgumentParser(description="SQuAD Text Dataset to Tokenized Numpy Converter")
+    parser.add_argument("--model-id", type=str, default="csarron/bert-base-uncased-squad-v1", help="QA용 사전학습된 토크나이저 이름 (NPU 엣지 벤치마킹용 bert-base)")
+    parser.add_argument("--seq-len", type=int, default=384, help="Context가 길기 때문에 QA 모델은 보통 384 차원을 규격으로 사용함")
+    parser.add_argument("--dataset-name", type=str, default="squad", help="HF 데이터셋 (기본: squad v1.1)")
+    parser.add_argument("--split", type=str, default="validation", help="벤치마크 평가용 스플릿 (기본: validation)")
+    
+    # 출력 경로 기본값
+    parser.add_argument("--output-dir", "-o", type=str, default=os.path.join(os.path.dirname(__file__), "../datasets/baked_numpy/squad_val"), help="npy 파일 저장 절대 경로")
+    args = parser.parse_args()
+
+    # 1. 원본 데이터 로드 (validation 셋만 부름 - 벤치마크 목적)
+    print(f"[*] HuggingFace 허브 데이터셋 로딩 중: {args.dataset_name}, split={args.split}...")
+    try:
+        dataset = load_dataset(args.dataset_name, split=args.split)
+    except Exception as e:
+        print(f"[Error] 데이터셋 파싱 실패: {e}")
+        return
+        
+    print(f"[*] Тоkenizer 로딩 중: {args.model_id}...")
+    tokenizer = AutoTokenizer.from_pretrained(args.model_id)
+
+    # 파싱될 배열 수급용 임시 리스트
+    all_input_ids = []
+    all_attention_masks = []
+    all_start_positions = []
+    all_end_positions = []
+
+    print(f"[*] {len(dataset)}개 샘플 Token-Offset Mapping 진행 중 (Length={args.seq_len})...")
+    
+    # 2. 토크나이징 및 Character -> Token Offset 스위칭 로직 (순수 파이썬 + HF Iterator)
+    # batched=True 매핑은 offset 처리가 복잡하므로 명시적인 반복 순해석(Iteration)으로 안정성 확보
+    for i, example in enumerate(dataset):
+        # 질문(Question)과 지문(Context) 쌍
+        question = example["question"]
+        context = example["context"]
+        
+        # SQuAD Validation 셋은 복수의 정답(Human Annotators)을 가짐
+        # 모델 비교 성능 측정을 위해 관례대로 '첫 번째' 정답만 타겟팅
+        answers = example["answers"]
+        
+        # 정답이 아예 없는 예외 케이스(SQuAD v2) 방어. v1은 항상 정답이 있음.
+        if len(answers["text"]) == 0:
+            continue
+            
+        answer_text = answers["text"][0]
+        answer_start_char = answers["answer_start"][0]
+        answer_end_char = answer_start_char + len(answer_text)
+
+        # 토크나이징 (question과 context를 "[CLS] Q [SEP] C [SEP]" 구조로 병합)
+        tokenized = tokenizer(
+            question,
+            context,
+            max_length=args.seq_len,
+            padding="max_length",
+            truncation="only_second", # 긴 지문(context)만 적당히 잘라냄
+            return_offsets_mapping=True, # 여기가 핵심! 토큰이 텍스트의 몇 번째 글자에 해당하는지 담김
+        )
+        
+        offset_mapping = tokenized["offset_mapping"]
+        # 어느 부분이 질문이고 어느 부분이 지문인지 식별 (None=스페셜, 0=Question, 1=Context)
+        sequence_ids = tokenized.sequence_ids()
+
+        # Context의 토큰 시작/끝 인덱스를 파악 (SEP 등 스페셜 토큰 제외)
+        context_start_token = 0
+        while sequence_ids[context_start_token] != 1:
+            context_start_token += 1
+            if context_start_token >= len(sequence_ids):
+                break # 에러 엣지 케이스
+                
+        context_end_token = len(sequence_ids) - 1
+        while sequence_ids[context_end_token] != 1:
+            context_end_token -= 1
+
+        # 정답 글자가 지문(Context) 배열의 완전 바깥에 잘린(Truncation) 경우 정답 오프셋을 0으로 묵살
+        if context_start_token >= len(sequence_ids) or \
+           offset_mapping[context_start_token][0] > answer_start_char or \
+           offset_mapping[context_end_token][1] < answer_end_char:
+            target_start = 0
+            target_end = 0
+        else:
+            # Token 인덱스를 추적하여 실제 `answer_start` 캐릭터 위치를 커버하는 토큰 번호를 찾음
+            idx = context_start_token
+            while idx <= context_end_token and offset_mapping[idx][0] <= answer_start_char:
+                idx += 1
+            target_start = idx - 1
+
+            # Token 인덱스를 추적하여 `answer_end` 캐릭터 위치를 커버하는 토큰 번호를 찾음
+            idx = context_end_token
+            while idx >= context_start_token and offset_mapping[idx][1] >= answer_end_char:
+                idx -= 1
+            target_end = idx + 1
+
+        all_input_ids.append(tokenized["input_ids"])
+        all_attention_masks.append(tokenized["attention_mask"])
+        all_start_positions.append(target_start)
+        all_end_positions.append(target_end)
+        
+        if (i+1) % 2000 == 0:
+            print(f"   ... Processed {i+1} / {len(dataset)} samples")
+
+    # 3. 누적된 파이썬 리스트를 O(1) Numpy 벡터 통짜 데이터로 묶음
+    np_input_ids = np.asarray(all_input_ids, dtype=np.int64)
+    np_attention_mask = np.asarray(all_attention_masks, dtype=np.int64)
+    np_start_positions = np.asarray(all_start_positions, dtype=np.int64)
+    np_end_positions = np.asarray(all_end_positions, dtype=np.int64)
+
+    # 4. 디스크 영구 저장
+    os.makedirs(args.output_dir, exist_ok=True)
+    
+    id_path = os.path.join(args.output_dir, "input_ids.npy")
+    mask_path = os.path.join(args.output_dir, "attention_mask.npy")
+    start_path = os.path.join(args.output_dir, "start_positions.npy")
+    end_path = os.path.join(args.output_dir, "end_positions.npy")
+    
+    np.save(id_path, np_input_ids)
+    np.save(mask_path, np_attention_mask)
+    np.save(start_path, np_start_positions)
+    np.save(end_path, np_end_positions)
+
+    print("\n[SUCCESS] SQuAD 오프라인 베이킹(.npy) 완료! 🥐")
+    print(f"  - Input IDs      : {np_input_ids.shape} -> '{id_path}'")
+    print(f"  - Attention Mask : {np_attention_mask.shape} -> '{mask_path}'")
+    print(f"  - Target Starts  : {np_start_positions.shape} -> '{start_path}'")
+    print(f"  - Target Ends    : {np_end_positions.shape} -> '{end_path}'")
+
+if __name__ == "__main__":
+    main()

--- a/runtime-env/src/dataloader/image_classification_loader.py
+++ b/runtime-env/src/dataloader/image_classification_loader.py
@@ -61,6 +61,8 @@ class ImageClassificationLoader(DataLoader):
                             self.labels_map[parts[0]] = int(parts[1])
 
         self.total_samples = len(self.image_files)
+        if self.total_samples == 0:
+            raise FileNotFoundError(f"[ImageClassificationLoader] '{self.image_dir}' 경로에 이미지가 존재하지 않습니다. 데이터셋 경로를 점검하거나 다운로드를 확인해 주세요.")
         self.current_idx   = 0
 
         # 3. 입력 형상(H, W) 파싱

--- a/runtime-env/src/dataloader/object_detection_loader.py
+++ b/runtime-env/src/dataloader/object_detection_loader.py
@@ -35,6 +35,8 @@ class ObjectDetectionLoader(DataLoader):
             ])
             
         self.total_samples = len(self.image_files)
+        if self.total_samples == 0:
+            raise FileNotFoundError(f"[ObjectDetectionLoader] '{self.image_dir}' 경로에 이미지가 존재하지 않습니다. 데이터셋 경로를 점검하거나 다운로드를 다시 진행해 주세요.")
         self.current_idx = 0
         
         # 3. 모델 정보 기반 속성 파싱


### PR DESCRIPTION
## 🚀 변경 사항 요약 (Summary)
이번 PR에서는 BERT SQuAD 데이터 전처리와 로컬 벤치마크 환경 구성의 편의성을 높이기 위한 유틸리티 및 방어 로직을 추가했습니다.
주요 변경 사항은 SQuAD 오프라인 분해 스크립트 작성, YOLOv5m 자동화 스크립트 추가, 그리고 빈 데이터셋 진입 시 발생하는 에러를 조기에 차단하는 Fail-fast 로직 도입입니다.

<br/>

## ✨ 상세 변경 내역 (Changes)

### 1. BERT SQuAD 전처리 스크립트 추가 (`feat`)
- **Numpy 오프라인 데이터 분해:** HuggingFace 데이터셋(`squad`)을 로드하여 `offset_mapping`을 기반으로 위치 인덱스 구조로 변환하는 스크립트를 작성했습니다.
- **Numpy 캐싱:** 연산 결과를 디스크에 4종의 고속 로딩 파일(`input_ids.npy`, `attention_mask.npy`, `start_positions.npy`, `end_positions.npy`)로 추출 및 저장합니다.

### 2. 로컬 벤치마크 자동화 유틸리티 추가 (`feat`)
- **`load_coco128.py` 추가:** 공식 GitHub 릴리즈에서 `COCO128` 데이터셋을 `.zip` 다운로드 후 `datasets/` 위치에 자동 압축 해제합니다.
- **`download_yolov5m.py` 추가:** 최신 패키지를 기반으로 사전에 학습된 파이토치 가중치를 받아와 `models/` 내에 ONNX 포맷으로 즉시 자동 변환합니다.
- 💡 **경로 무결성:** 스크립트의 실행 위치(`root` or `scripts/`)와 무관하게 프로젝트 루트를 절대 경로로 추적하도록 구성했습니다.

### 3. DataLoader Fail-Fast 예외 처리 강화 (`fix`)
- **설명:** 기존에는 데이터 폴더가 비어있어도 벤치마크 루프가 정상인 것처럼 0번 실행되고, 마지막 채점기(`Evaluator`)의 출력 단계에서 `IndexError`가 터지는 현상이 있었습니다.
- **조치:** `ObjectDetectionLoader`와 `ImageClassificationLoader` 초기화 프로세스에 데이터 개수 검증 레이어를 추가했습니다. 데이터가 `0`장이면 런타임을 헛돌게 하지 않고 즉시 `FileNotFoundError`를 발생시키며(Fail-Fast) 엔진을 안전하게 중단합니다.

<br/>

## 🛠️ 확인/테스트 사항 (Verification)
- [x] SQuAD 데이터셋이 4종의 `.npy` 배열로 정상 추출되는가?
- [x] 다운로드 스크립트(`load_coco128`, `download_yolov5m`)가 경로가 다를 때 문제 없이 데이터와 모델을 알맞은 위치에 안착시키는가?
- [x] Image 데이터셋 폴더를 의도적으로 비웠을 때, 벤치마크가 파이프라인 진행 전에 안전하게 `FileNotFoundError`를 발생시키며 꺼지는가?

<br/>


